### PR TITLE
Bump v0.1.8 policy version.

### DIFF
--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,27 +4,27 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.7
+version: 0.1.8
 name: disallow-service-loadbalancer
 displayName: Disallow Service Loadbalancer
-createdAt: 2023-03-24T16:38:25.289710085Z
+createdAt: 2023-07-07T18:01:28.597620555Z
 description: A policy that prevents the creation of Service resources of type `LoadBalancer`
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/disallow-service-loadbalancer-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/disallow-service-loadbalancer:v0.1.7
+  image: ghcr.io/kubewarden/policies/disallow-service-loadbalancer:v0.1.8
 keywords:
 - service
 links:
 - name: policy
-  url: https://github.com/kubewarden/disallow-service-loadbalancer-policy/releases/download/v0.1.7/policy.wasm
+  url: https://github.com/kubewarden/disallow-service-loadbalancer-policy/releases/download/v0.1.8/policy.wasm
 - name: source
   url: https://github.com/kubewarden/disallow-service-loadbalancer-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/disallow-service-loadbalancer:v0.1.7
+  kwctl pull ghcr.io/kubewarden/policies/disallow-service-loadbalancer:v0.1.8
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.8 policy version.

Updates the Cargo and artifacthub files bumping the policy version to v0.1.8

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
